### PR TITLE
Fix for Timing Points: Speed and Time were swapped

### DIFF
--- a/osu-database-reader/CustomReader.cs
+++ b/osu-database-reader/CustomReader.cs
@@ -58,8 +58,8 @@ namespace osu_database_reader
 
         private TimingPoint ReadTimingPoint() {
             TimingPoint t = new TimingPoint {
-                Time = ReadDouble(),
                 Speed = ReadDouble(),
+                Time = ReadDouble(),
                 NotInherited = ReadByte()
             };
             return t;

--- a/osu-database-reader/CustomReader.cs
+++ b/osu-database-reader/CustomReader.cs
@@ -58,9 +58,9 @@ namespace osu_database_reader
 
         private TimingPoint ReadTimingPoint() {
             TimingPoint t = new TimingPoint {
-                Speed = ReadDouble(),
+                MsPerQuarter = ReadDouble(),
                 Time = ReadDouble(),
-                NotInherited = ReadByte()
+                NotInherited = ReadByte() != 0
             };
             return t;
         }

--- a/osu-database-reader/Structs.cs
+++ b/osu-database-reader/Structs.cs
@@ -8,8 +8,8 @@ namespace osu_database_reader
 {
     public struct TimingPoint
     {
-        public double Time, Speed;
-        public byte NotInherited;
+        public double Time, MsPerQuarter;
+        public bool NotInherited;
     }
 
     public struct Collection


### PR DESCRIPTION
Fixed reading timing points; time was read into "Speed", and milliseconds per quarter was read into "Time".

See also: https://github.com/HoLLy-HaCKeR/osu-database-reader/issues/2